### PR TITLE
Fix for Edge on Windows Phone

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -66,6 +66,7 @@ function FusionPoseSensor(kFilter, predictionTime, touchPannerDisabled, yawOnly,
   // Keep track of a reset transform for resetSensor.
   this.resetQ = new MathUtil.Quaternion();
 
+  this.isEdgeWindowsPhone = Util.isEdgeWindowsPhone();
   this.isFirefoxAndroid = Util.isFirefoxAndroid();
   this.isIOS = Util.isIOS();
 
@@ -166,9 +167,9 @@ FusionPoseSensor.prototype.updateDeviceMotion_ = function(deviceMotion) {
     this.gyroscope.set(rotRate.alpha, rotRate.beta, rotRate.gamma);
   }
 
-  // With iOS and Firefox Android, rotationRate is reported in degrees,
-  // so we first convert to radians.
-  if (this.isIOS || this.isFirefoxAndroid) {
+  // With iOS, Firefox Android, and Edge on Windows Phone, rotationRate
+  // is reported in degrees, so we first convert to radians.
+  if (this.isIOS || this.isFirefoxAndroid || this.isEdgeWindowsPhone) {
     this.gyroscope.multiplyScalar(Math.PI / 180);
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -72,6 +72,14 @@ Util.isSafari = (function() {
   };
 })();
 
+Util.isEdgeWindowsPhone = (function() {
+  var isEdgeWindowsPhone = navigator.userAgent.indexOf('Windows Phone') !== -1 &&
+                           navigator.userAgent.indexOf('Edge') !== -1;
+  return function() {
+    return isEdgeWindowsPhone;
+  };
+})();
+
 Util.isFirefoxAndroid = (function() {
   var isFirefoxAndroid = navigator.userAgent.indexOf('Firefox') !== -1 &&
       navigator.userAgent.indexOf('Android') !== -1;


### PR DESCRIPTION
When on Edge on Windows Phone, devicemotion events rotationRate is in degrees, not radians. Fixes https://github.com/googlevr/webvr-polyfill/issues/139

Note that we must make a distinction for Windows Phone, because Edge on Android reports the values in radians.

TODO:
- [x] Test Edge on iOS and confirm the correct behavior still works once adding this Edge check
- [ ] Test Edge on Windows Phone (no device handy, will crowd source)