### PR TITLE
When calling requestPresent with a new `source`, swap without leaving fullscreen.

### DIFF
--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -253,6 +253,15 @@ CardboardVRDisplay.prototype.endPresent_ = function() {
   window.removeEventListener('vrdisplaypresentchange', this.vrdisplaypresentchangeHandler);
 };
 
+/**
+ * Called when the layer's `source` changes to a new canvas.
+ * Used to re-setup the distortions and UI with new context.
+ */
+CardboardVRDisplay.prototype.updatePresent_ = function() {
+  this.endPresent_();
+  this.beginPresent_();
+};
+
 CardboardVRDisplay.prototype.submitFrame = function(pose) {
   if (this.distorter_) {
     this.updateBounds_();


### PR DESCRIPTION
When calling requestPresent with a new canvas, do not exit fullscreen and swap canvases. Necessary for presenting via user-gesture before a canvas can be acquired, like for the WebXR polyfill, which needs to create a session via user-gesture, but does not have a canvas until `baseLayer` is set. Similarly in polyfill land, there are browsers that require a user-gesture for fullscreen (at least Firefox/Android from my testing). In order to polyfill a WebXR style way of presenting on Cardboard/1.1, we must call `requestPresent` with a dummy canvas and preserve the fullscreen request, and subsequently call `requestPresent` again with the real canvas from the session's `baseLayer`.