### PR TITLE
Add support for additional VR viewers parameters to be passed in

### DIFF
--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -61,9 +61,10 @@ function CardboardVRDisplay(config) {
   this.cardboardUI_ = null;
 
   this.dpdb_ = new Dpdb(this.config.DPDB_URL, this.onDeviceParamsUpdated_.bind(this));
-  this.deviceInfo_ = new DeviceInfo(this.dpdb_.getDeviceParams());
+  this.deviceInfo_ = new DeviceInfo(this.dpdb_.getDeviceParams(),
+                                    config.ADDITIONAL_VIEWERS);
 
-  this.viewerSelector_ = new ViewerSelector();
+  this.viewerSelector_ = new ViewerSelector(config.DEFAULT_VIEWER);
   this.viewerSelector_.onChange(this.onViewerChanged_.bind(this));
 
   // Set the correct initial viewer.

--- a/src/device-info.js
+++ b/src/device-info.js
@@ -81,10 +81,14 @@ var DEFAULT_RIGHT_CENTER = {x: 0.5, y: 0.5};
  * obtained from dpdb.getDeviceParams()). Can be null to mean no device
  * params were found.
  */
-function DeviceInfo(deviceParams) {
+function DeviceInfo(deviceParams, additionalViewers) {
   this.viewer = Viewers.CardboardV2;
   this.updateDeviceParams(deviceParams);
   this.distortion = new Distortion(this.viewer.distortionCoefficients);
+  for (var i = 0; i < additionalViewers.length; i++) {
+    var viewer = additionalViewers[i];
+    Viewers[viewer.id] = new CardboardViewer(viewer);
+  }
 }
 
 DeviceInfo.prototype.updateDeviceParams = function(deviceParams) {

--- a/src/viewer-selector.js
+++ b/src/viewer-selector.js
@@ -25,7 +25,7 @@ const CLASS_NAME = 'webvr-polyfill-viewer-selector';
  * and hidden. Generates events when viewer parameters change. Also supports
  * saving the currently selected index in localStorage.
  */
-function ViewerSelector() {
+function ViewerSelector(defaultViewer) {
   // Try to load the selected key from local storage.
   try {
     this.selectedKey = localStorage.getItem(VIEWER_KEY);
@@ -35,7 +35,7 @@ function ViewerSelector() {
 
   //If none exists, or if localstorage is unavailable, use the default key.
   if (!this.selectedKey) {
-    this.selectedKey = DEFAULT_VIEWER;
+    this.selectedKey = defaultViewer || DEFAULT_VIEWER;
   }
 
   this.dialog = this.createDialog_(DeviceInfo.Viewers);


### PR DESCRIPTION
Allows for other viewer parameters to be used. The goal is to then be able to do this:
```
var polyfill = new WebVRPolyfill({
    ADDITIONAL_VIEWERS: [{
        id: 'Some_different_cardboard_viewer',
        label: 'My Best Viewer',
        fov: 50,
        interLensDistance: 0.053,
        baselineLensDistance: 0.035,
        screenLensDistance: 0.053,
        distortionCoefficients: [0.15, 0.11],
    }],
    DEFAULT_VIEWER: 'Some_different_cardboard_viewer',
});
```

and have the new viewer present in the list when clicking on the gear icon.