### PR TITLE
Fallback to device motion events if the Sensor emits an error event

### DIFF
--- a/src/pose-sensor.js
+++ b/src/pose-sensor.js
@@ -124,6 +124,11 @@ export default class PoseSensor {
                                              this.config.PREDICTION_TIME_S,
                                              this.config.YAW_ONLY,
                                              this.config.DEBUG);
+    if (this.sensor) {
+      this.sensor.removeEventListener('reading', this._onSensorRead);
+      this.sensor.removeEventListener('error', this._onSensorError);
+      this.sensor = null;
+    }
   }
 
   getOrientation() {
@@ -169,6 +174,7 @@ export default class PoseSensor {
     } else {
       console.error(event.error);
     }
+    this.useDeviceMotion();
   }
 
   _onSensorRead() {}


### PR DESCRIPTION
Currently, when using the Sensor API, if it's not possible to create, we fall back to device motion. What isn't handled is when the sensor emits an `error` event -- it does not currently fall back to device motion.

Unfortunately, I'm not sure how to test this without devices that do not support these features, such that would create an async failure, as opposed to the synchronous thrown errors. Any ideas? @cvan @kenchris @pozdnyakov