### PR TITLE
Check for existence of "screen" global before using

### DIFF
--- a/src/pose-sensor.js
+++ b/src/pose-sensor.js
@@ -25,9 +25,9 @@ const X_AXIS = new Vector3(1, 0, 0);
 const Z_AXIS = new Vector3(0, 0, 1);
 
 let orientation = {};
-if (screen.orientation) {
+if ((typeof screen !== 'undefined') && screen.orientation) {
   orientation = screen.orientation;
-} else if (screen.msOrientation) {
+} else if ((typeof screen !== 'undefined') && screen.msOrientation) {
   orientation = screen.msOrientation;
 } else {
   Object.defineProperty(orientation, 'angle', {


### PR DESCRIPTION
This is needed to be able to import with node/build with ember-cli

fixes immersive-web/webvr-polyfill#322
replaces https://github.com/immersive-web/webvr-polyfill/pull/323

