### PR TITLE
fix motion events detection for iOS 13.4, which are broken

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -41,10 +41,10 @@ function FusionPoseSensor(kFilter, predictionTime, yawOnly, isDebug) {
   // https://github.com/immersive-web/cardboard-vr-display/issues/18
   let chromeVersion = Util.getChromeVersion();
   this.isDeviceMotionInRadians = !this.isIOS && chromeVersion && chromeVersion < 66;
-  // In Chrome m65 there's a regression of devicemotion events. Fallback
+  // In Chrome m65 and Safari 13.4 there's a regression of devicemotion events. Fallback
   // to using deviceorientation for these specific builds. More information
   // at `Util.isChromeWithoutDeviceMotion`.
-  this.isWithoutDeviceMotion = Util.isChromeWithoutDeviceMotion();
+  this.isWithoutDeviceMotion = Util.isChromeWithoutDeviceMotion() || Util.isSafariWithoutDeviceMotion();
 
   this.filterToWorldQ = new MathUtil.Quaternion();
 

--- a/src/util.js
+++ b/src/util.js
@@ -72,6 +72,17 @@ export const getChromeVersion = (function() {
 })();
 
 /**
+ * In Safari 13.4 for iOS `devicemotion` events are broken
+ */
+export const isSafariWithoutDeviceMotion = (function() {
+  let value = false;
+  value = isIOS() && isSafari() && navigator.userAgent.indexOf('13_4') !== -1;
+  return function () {
+    return value;
+  };
+})();
+
+/**
  * In Chrome m65, `devicemotion` events are broken but subsequently fixed
  * in 65.0.3325.148. Since many browsers use Chromium, ensure that
  * we scope this detection by branch and build numbers to provide


### PR DESCRIPTION
This will fix [immersive-web/webxr-polyfill](https://github.com/immersive-web/webxr-polyfill/issues/137) and basically any app out there which uses that webxr-polyfill (including [the webxr-examples](https://github.com/immersive-web/webxr-samples) when apply the one another pre-grant permissions condition on iOS).
This fix is needed because [devicemotion is broken in Safari for iOS 13.4](https://stackoverflow.com/questions/61339598/devicemotion-rotationrate-is-null-on-ios-13-4), (as it was on Chrome m65).
So this PR adds the double condition to the actual `isWithoutDeviceMotion` variable.